### PR TITLE
make scalarmappable callable

### DIFF
--- a/lib/matplotlib/cm.py
+++ b/lib/matplotlib/cm.py
@@ -435,6 +435,15 @@ class ScalarMappable:
         # rather than deferring to draw time.
         self.autoscale_None()
 
+    def __call__(self, x, alpha=None, bytes=False, norm=True):
+        """
+        Return a normalized RGBA array corresponding to *x*.
+
+        This is a convenience function that is identical to ``to_rgba``. For 
+        more information, see the documentation for that method. 
+        """
+        return self.to_rgba(x, alpha=alpha, bytes=bytes, norm=norm)
+      
     def to_rgba(self, x, alpha=None, bytes=False, norm=True):
         """
         Return a normalized RGBA array corresponding to *x*.


### PR DESCRIPTION
## PR summary
Make ScalarMappable callable for ease of use and interchangeable use with `colormaps`. Related to issue #26911

### Testing:
All tests passed except for one function related to pickle loading (which came with the warning indicating that it is unlikely to function, see below for details).

```
Results (342.88s (0:05:42)):
    7929 passed
       2 xpassed
       1 failed
         - lib\matplotlib\testing/decorators.py:398 test_pickle_load_from_subprocess[png]
      78 xfailed
    1668 skipped
```

Related warning: 
```
FAILED lib/matplotlib/tests/test_pickle.py::test_pickle_load_from_subprocess[png] - UserWarning: This figure was saved with matplotlib version 3.9.0.dev290+g7d2acfda30.d19700101 and is unlikely to fu...
```
 
## PR checklist
- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html). 
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] It's a very small change, so not sure if this should include a new feature or API change note.
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
